### PR TITLE
fix(path): fix `replaceSepToWin32`, `replaceSepToPosix`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: ctix
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - run: pnpm install
+    - run: pnpm run build
+    - run: pnpm run clean
+    - run: pnpm run test:ci
+    - run: pnpm run clean
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
+++ b/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
@@ -4,32 +4,39 @@ import { describe, expect, it, vitest } from 'vitest';
 
 describe('replaceSepToPosix', () => {
   it('not changed directory', () => {
+    const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
     const r01 = replaceSepToPosix('/1/2/3/4');
+    handle.mockRestore();
+
     expect(r01).toEqual('/1/2/3/4');
   });
 
   describe('win32', () => {
+    it('empty directory', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
+      const r01 = replaceSepToPosix('');
+      handle.mockRestore();
+      expect(r01).toEqual('');
+    });
+
     it('starts with slash', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('\\1\\2\\3\\4');
-
-      handle.mockClear();
+      handle.mockRestore();
       expect(r01).toEqual('/1/2/3/4');
     });
 
     it('starts with dot', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('.\\1\\2\\3\\4');
-
-      handle.mockClear();
+      handle.mockRestore();
       expect(r01).toEqual('./1/2/3/4');
     });
 
     it('starts with alphabets', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('1\\2\\3\\4');
-
-      handle.mockClear();
+      handle.mockRestore();
       expect(r01).toEqual('1/2/3/4');
     });
   });

--- a/src/replaceSepToPosix/replaceSepToPosix.ts
+++ b/src/replaceSepToPosix/replaceSepToPosix.ts
@@ -4,6 +4,10 @@ import path from 'node:path';
 export function replaceSepToPosix(targetPath: string): string {
   const sep = getSep();
 
+  if (targetPath === '') {
+    return targetPath;
+  }
+
   if (sep !== path.posix.sep) {
     const replaced = path.posix.join(...targetPath.split(sep));
 

--- a/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
+++ b/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
@@ -6,33 +6,37 @@ describe('replaceSepToWin32', () => {
   it('not changed directory', () => {
     const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
     const r01 = replaceSepToWin32('\\1\\2\\3\\4');
-    handle.mockReset();
+    handle.mockRestore();
 
     expect(r01).toEqual('\\1\\2\\3\\4');
   });
 
-  describe('win32', () => {
+  describe('posix', () => {
+    it('empty directory', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
+      const r01 = replaceSepToWin32('');
+      handle.mockRestore();
+      expect(r01).toEqual('');
+    });
+
     it('starts with slash', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('/1/2/3/4');
-      handle.mockReset();
-
+      handle.mockRestore();
       expect(r01).toEqual('\\1\\2\\3\\4');
     });
 
     it('starts with dot', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('./1/2/3/4');
-      handle.mockReset();
-
+      handle.mockRestore();
       expect(r01).toEqual('.\\1\\2\\3\\4');
     });
 
     it('starts with alphabets', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('1/2/3/4');
-      handle.mockReset();
-
+      handle.mockRestore();
       expect(r01).toEqual('1\\2\\3\\4');
     });
   });

--- a/src/replaceSepToWin32/replaceSepToWin32.ts
+++ b/src/replaceSepToWin32/replaceSepToWin32.ts
@@ -4,6 +4,10 @@ import path from 'node:path';
 export function replaceSepToWin32(targetPath: string): string {
   const sep = getSep();
 
+  if (targetPath === '') {
+    return targetPath;
+  }
+
   if (sep !== path.win32.sep) {
     const replaced = path.win32.join(...targetPath.split(sep));
 


### PR DESCRIPTION
- fixed returning incorrect results when the input directory is empty