### PR TITLE
fix(path): fix `replaceSepToWin32`, `replaceSepToPosix`

### DIFF
--- a/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
+++ b/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
@@ -33,6 +33,13 @@ describe('replaceSepToPosix', () => {
       expect(r01).toEqual('./1/2/3/4');
     });
 
+    it('starts with double dot', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
+      const r01 = replaceSepToPosix('..\\1\\2\\3\\4');
+      handle.mockRestore();
+      expect(r01).toEqual('../1/2/3/4');
+    });
+
     it('starts with alphabets', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('1\\2\\3\\4');

--- a/src/replaceSepToPosix/replaceSepToPosix.ts
+++ b/src/replaceSepToPosix/replaceSepToPosix.ts
@@ -15,6 +15,10 @@ export function replaceSepToPosix(targetPath: string): string {
       return `${path.posix.sep}${replaced}`;
     }
 
+    if (targetPath.startsWith('..') && !replaced.startsWith(sep)) {
+      return replaced;
+    }
+
     if (targetPath.startsWith('.') && !replaced.startsWith(sep)) {
       return ['.', replaced].join(path.posix.sep);
     }

--- a/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
+++ b/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
@@ -33,6 +33,13 @@ describe('replaceSepToWin32', () => {
       expect(r01).toEqual('.\\1\\2\\3\\4');
     });
 
+    it('starts with double dot', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
+      const r01 = replaceSepToWin32('../1/2/3/4');
+      handle.mockRestore();
+      expect(r01).toEqual('..\\1\\2\\3\\4');
+    });
+
     it('starts with alphabets', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('1/2/3/4');

--- a/src/replaceSepToWin32/replaceSepToWin32.ts
+++ b/src/replaceSepToWin32/replaceSepToWin32.ts
@@ -15,6 +15,10 @@ export function replaceSepToWin32(targetPath: string): string {
       return `${path.win32.sep}${replaced}`;
     }
 
+    if (targetPath.startsWith('..') && !replaced.startsWith(sep)) {
+      return replaced;
+    }
+
     if (targetPath.startsWith('.') && !replaced.startsWith(sep)) {
       return ['.', replaced].join(path.win32.sep);
     }


### PR DESCRIPTION
- fixed an issue when starting with an parent directory (`..`)