### PR TITLE
fix(path): fix `replaceSepToWin32`, `replaceSepToPosix`

### DIFF
--- a/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
+++ b/src/replaceSepToPosix/__tests__/replace.sep.to.posix.test.ts
@@ -26,14 +26,38 @@ describe('replaceSepToPosix', () => {
       expect(r01).toEqual('/1/2/3/4');
     });
 
-    it('starts with dot', () => {
+    it('single dot', () => {
+      const r01 = replaceSepToPosix('.');
+      expect(r01).toEqual('.');
+    });
+
+    it('double dot', () => {
+      const r01 = replaceSepToPosix('..');
+      expect(r01).toEqual('..');
+    });
+
+    it('starts with dot - 1', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
+      const r01 = replaceSepToPosix('.\\1');
+      handle.mockRestore();
+      expect(r01).toEqual('./1');
+    });
+
+    it('starts with dot - 2', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('.\\1\\2\\3\\4');
       handle.mockRestore();
       expect(r01).toEqual('./1/2/3/4');
     });
 
-    it('starts with double dot', () => {
+    it('starts with double dot - 1', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
+      const r01 = replaceSepToPosix('..\\1');
+      handle.mockRestore();
+      expect(r01).toEqual('../1');
+    });
+
+    it('starts with double dot - 2', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '\\');
       const r01 = replaceSepToPosix('..\\1\\2\\3\\4');
       handle.mockRestore();

--- a/src/replaceSepToPosix/replaceSepToPosix.ts
+++ b/src/replaceSepToPosix/replaceSepToPosix.ts
@@ -8,6 +8,14 @@ export function replaceSepToPosix(targetPath: string): string {
     return targetPath;
   }
 
+  if (targetPath.trim() === '.') {
+    return targetPath.trim();
+  }
+
+  if (targetPath.trim() === '..') {
+    return targetPath.trim();
+  }
+
   if (sep !== path.posix.sep) {
     const replaced = path.posix.join(...targetPath.split(sep));
 

--- a/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
+++ b/src/replaceSepToWin32/__tests__/replace.sep.to.win32.test.ts
@@ -19,6 +19,16 @@ describe('replaceSepToWin32', () => {
       expect(r01).toEqual('');
     });
 
+    it('single dot', () => {
+      const r01 = replaceSepToWin32('.');
+      expect(r01).toEqual('.');
+    });
+
+    it('double dot', () => {
+      const r01 = replaceSepToWin32('..');
+      expect(r01).toEqual('..');
+    });
+
     it('starts with slash', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('/1/2/3/4');
@@ -26,14 +36,28 @@ describe('replaceSepToWin32', () => {
       expect(r01).toEqual('\\1\\2\\3\\4');
     });
 
-    it('starts with dot', () => {
+    it('starts with dot - 1', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
+      const r01 = replaceSepToWin32('./1');
+      handle.mockRestore();
+      expect(r01).toEqual('.\\1');
+    });
+
+    it('starts with dot - 2', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('./1/2/3/4');
       handle.mockRestore();
       expect(r01).toEqual('.\\1\\2\\3\\4');
     });
 
-    it('starts with double dot', () => {
+    it('starts with double dot - 1', () => {
+      const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
+      const r01 = replaceSepToWin32('../1');
+      handle.mockRestore();
+      expect(r01).toEqual('..\\1');
+    });
+
+    it('starts with double dot - 2', () => {
       const handle = vitest.spyOn(gs, 'getSep').mockImplementationOnce(() => '/');
       const r01 = replaceSepToWin32('../1/2/3/4');
       handle.mockRestore();

--- a/src/replaceSepToWin32/replaceSepToWin32.ts
+++ b/src/replaceSepToWin32/replaceSepToWin32.ts
@@ -8,6 +8,14 @@ export function replaceSepToWin32(targetPath: string): string {
     return targetPath;
   }
 
+  if (targetPath.trim() === '.') {
+    return targetPath.trim();
+  }
+
+  if (targetPath.trim() === '..') {
+    return targetPath.trim();
+  }
+
   if (sep !== path.win32.sep) {
     const replaced = path.win32.join(...targetPath.split(sep));
 


### PR DESCRIPTION
- fixed an issue when starting with single dot, double dot